### PR TITLE
[Fix] Filter bot requests in shouldNotFilter

### DIFF
--- a/src/main/java/com/cpa/yusin/quiz/global/filter/UserCountFilter.java
+++ b/src/main/java/com/cpa/yusin/quiz/global/filter/UserCountFilter.java
@@ -1,5 +1,6 @@
 package com.cpa.yusin.quiz.global.filter;
 
+import com.cpa.yusin.quiz.global.utils.VisitorWhiteListMatcher;
 import com.cpa.yusin.quiz.visitor.service.VisitorService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -13,7 +14,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Order(2)
@@ -22,8 +23,7 @@ import java.util.List;
 public class UserCountFilter extends OncePerRequestFilter
 {
     private final VisitorService visitorService;
-
-    List<String> WHITE_LIST = List.of("/css", "/js", "/favicon.ico", "/images");
+    private final VisitorWhiteListMatcher whiteListMatcher;
 
     @Override
     protected void doFilterInternal(@NonNull HttpServletRequest request,
@@ -42,8 +42,12 @@ public class UserCountFilter extends OncePerRequestFilter
     @Override
     protected boolean shouldNotFilter(@NonNull HttpServletRequest request) throws ServletException
     {
-        String path = request.getRequestURI();
+        String requestURI = request.getRequestURI();
+        String userAgent = Optional.ofNullable(request.getHeader("User-Agent")).orElse("").toLowerCase();
 
-        return WHITE_LIST.stream().anyMatch(path::startsWith);
+        log.info("Request URI: {}, User Agent: {}", requestURI, userAgent);
+
+        return whiteListMatcher.isWhiteListed(requestURI, userAgent);
     }
+
 }

--- a/src/main/java/com/cpa/yusin/quiz/global/utils/VisitorWhiteListMatcher.java
+++ b/src/main/java/com/cpa/yusin/quiz/global/utils/VisitorWhiteListMatcher.java
@@ -1,0 +1,48 @@
+package com.cpa.yusin.quiz.global.utils;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+public class VisitorWhiteListMatcher
+{
+    public static final List<String> PATH_WHITELIST = List.of("/css", "/js", "/favicon.ico", "/images");
+    public static final List<String> AGENT_WHITELIST = List.of(
+            // Common tools/scripts
+            "curl", "wget", "http.client", "python-requests", "okhttp", "apachehttpclient",
+            "java/", "go-http-client", "zgrab", "custom-asynchttpclient",
+
+            // Monitoring/CI/CD
+            "prometheus", "grafana", "newrelic", "datadog",
+            "github", "gitlab", "jenkins", "circleci",
+
+            // Security scanners
+            "nmap", "nessus", "openvas", "nikto", "acunetix",
+            "qualys", "netsparker", "burp", "owasp",
+
+            // Bots/Crawlers (broad coverage)
+            "bot", "crawler", "spider", "crawl", "slurp", "search",
+            "index", "scanner", "monitor", "probe",
+
+            "hookshot", "httpclient", "async", "monitoring", "python"
+    );
+
+    public boolean isWhiteListed(String uri, String userAgent)
+    {
+        return isWhiteListPath(uri) || isWhiteListAgent(userAgent);
+    }
+
+    private boolean isWhiteListPath(String uri)
+    {
+        return PATH_WHITELIST.stream().anyMatch(uri::startsWith);
+    }
+
+    private boolean isWhiteListAgent(String agent)
+    {
+        return AGENT_WHITELIST.stream().anyMatch(agent::contains);
+    }
+}
+

--- a/src/test/java/com/cpa/yusin/quiz/global/filter/UserCountFilterTest.java
+++ b/src/test/java/com/cpa/yusin/quiz/global/filter/UserCountFilterTest.java
@@ -1,15 +1,16 @@
 package com.cpa.yusin.quiz.global.filter;
 
+import com.cpa.yusin.quiz.global.utils.VisitorWhiteListMatcher;
 import com.cpa.yusin.quiz.visitor.service.VisitorService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletRequestWrapper;
 import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -17,9 +18,6 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -28,7 +26,7 @@ class UserCountFilterTest
     @Mock
     VisitorService visitorService;
 
-    MockHttpServletRequest servletRequest;
+    VisitorWhiteListMatcher whiteListMatcher;
 
     @Mock
     HttpServletResponse servletResponse;
@@ -41,16 +39,16 @@ class UserCountFilterTest
     @BeforeEach
     void setUp()
     {
-        servletRequest = new MockHttpServletRequest();
-        servletRequest.setRequestURI("/css");
-
-        userCountFilter = new UserCountFilter(visitorService);
+        whiteListMatcher = new VisitorWhiteListMatcher();
+        userCountFilter = new UserCountFilter(visitorService, whiteListMatcher);
     }
 
     @Test
     void doFilterInternal() throws ServletException, IOException
     {
         // given
+        MockHttpServletRequest servletRequest = new MockHttpServletRequest();
+        servletRequest.setRequestURI("/api/v1/");
 
         // when
         userCountFilter.doFilterInternal(servletRequest, servletResponse, filterChain);
@@ -60,11 +58,32 @@ class UserCountFilterTest
         verify(filterChain).doFilter(servletRequest, servletResponse);
     }
 
-    @DisplayName("should return true when the path is in WHITE LIST")
-    @Test
-    void shouldNotFilterWhenStartWithCss() throws ServletException
+    @DisplayName("should return true when the requestURI is in WHITE LIST")
+    @ValueSource(strings = {"/css", "/js", "/images", "/favicon.ico"})
+    @ParameterizedTest
+    void shouldNotFilterWhenRequestURIIsInWhiteList(String requestUri) throws ServletException
     {
         // given
+        MockHttpServletRequest servletRequest = new MockHttpServletRequest();
+        servletRequest.setRequestURI(requestUri);
+        servletRequest.addHeader("User-Agent", "Chrome");
+
+        // when
+        boolean result = userCountFilter.shouldNotFilter(servletRequest);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @DisplayName("should return true when the User-Agent is in WHITE LIST")
+    @ParameterizedTest
+    @ValueSource(strings = {"curl", "prometheus", "zgrab", "github", "bot", "spider", "crawler"})
+    void shouldNotFilterWhenUserAgentIsInWhiteList(String userAgent) throws ServletException
+    {
+        // given
+        MockHttpServletRequest servletRequest = new MockHttpServletRequest();
+        servletRequest.setRequestURI("/api/v1");
+        servletRequest.addHeader("User-Agent", userAgent);
 
         // when
         boolean result = userCountFilter.shouldNotFilter(servletRequest);
@@ -80,6 +99,7 @@ class UserCountFilterTest
         // given
         MockHttpServletRequest servletRequest = new MockHttpServletRequest();
         servletRequest.setRequestURI("/api/v1/");
+        servletRequest.addHeader("User-Agent", "Chrome");
 
         // when
         boolean result = userCountFilter.shouldNotFilter(servletRequest);


### PR DESCRIPTION
### Description of Changes
- Updated UserCounterFilter to skip requests from known bots or static resources by delegating whitelist logic to VisitorWhiteListMatcher.

### Key Changes
- [x] I have verified that the code works as expected.
- [x] I have added relevant tests (if applicable).
- [ ] Documentation has been updated (if necessary).

### Screenshots
- [ ] Add screenshots if necessary.
